### PR TITLE
Editing check functions to change output location

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Imports:
 	openxlsx
 Depends:
     R (>= 3.0.1)
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.0
 Suggests: knitr,
     rmarkdown
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,9 +2,15 @@ Package: inspectr
 Type: Package
 Title: Perform Basic Checks of Dataframes
 Version: 1.1.0
-Authors@R: person("Jennifer", "Brussow", email = "jbrussow@gmail.com", 
-  role = c("aut", "cre"))
-Maintainer: Jennifer Brussow <jbrussow@gmail.com>
+Authors@R: 
+c(person(given = "Noelle",
+         family = "Pablo",
+         role = c("aut", "cre"),
+         email = "noellebpablo@gmail.com"),
+ person(given = "Jennifer", 
+        family = "Brussow", 
+        role = "aut",
+        email = "jbrussow@gmail.com"))
 Description: Check one column or multiple columns of a dataframe
     using the preset basic checks or your own functions. Enables
     checks without knowledge of lapply() or sapply().
@@ -15,7 +21,7 @@ Imports:
 	openxlsx
 Depends:
     R (>= 3.0.1)
-RoxygenNote: 7.1.0
+RoxygenNote: 6.0.1
 Suggests: knitr,
     rmarkdown
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,14 +3,14 @@ Type: Package
 Title: Perform Basic Checks of Dataframes
 Version: 1.1.0
 Authors@R: 
-c(person(given = "Noelle",
-         family = "Pablo",
-         role = c("aut", "cre"),
-         email = "noellebpablo@gmail.com"),
- person(given = "Jennifer", 
-        family = "Brussow", 
-        role = "aut",
-        email = "jbrussow@gmail.com"))
+    c(person(given = "Noelle",
+             family = "Pablo",
+             role = c("aut", "cre"),
+             email = "noellebpablo@gmail.com"),
+      person(given = "Jennifer", 
+             family = "Brussow", 
+             role = "aut",
+             email = "jbrussow@gmail.com"))
 Description: Check one column or multiple columns of a dataframe
     using the preset basic checks or your own functions. Enables
     checks without knowledge of lapply() or sapply().
@@ -21,7 +21,7 @@ Imports:
 	openxlsx
 Depends:
     R (>= 3.0.1)
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.0
 Suggests: knitr,
     rmarkdown
 VignetteBuilder: knitr

--- a/R/col_checks.R
+++ b/R/col_checks.R
@@ -13,6 +13,9 @@
 #'   only records that failed the specified check. If TRUE, invisibly prints an
 #'   excel output file containing only the records that failed the specified
 #'   check.
+#' @param loc An optional character string that can be used to specify the desired 
+#' location of the error output. Can only be used when output = TRUE. If output = TRUE
+#' and loc is NULL, the error output gets put into the working directory.
 #' @param stage An optional character string that can be used to specify the
 #'   stage of the checking process in which the check is occurring. Only useful
 #'   if output = TRUE. If a value is specified, a that value is prefixed to the
@@ -34,14 +37,14 @@
 #'
 #' @export
 
-col_check <- function(colname, data, fun, output = FALSE, stage = NULL, ...) {
+col_check <- function(colname, data, fun, output = FALSE, loc = NULL, stage = NULL, ...) {
   check_name <- paste0(colname, "_check")
   data[,check_name] <- apply(data[colname], 1, FUN = fun, ...)
 
   if(sum(data[,check_name]) != nrow(data)){
     temp <- data[which(data[,check_name] != TRUE),]
     temp <- temp[, !names(temp) == check_name, drop = FALSE]
-    check_return(errors = temp, output = output, stage = stage, check_name =
+    check_return(errors = temp, output = output, loc = loc, stage = stage, check_name =
                    check_name)
   }
 }
@@ -63,6 +66,9 @@ col_check <- function(colname, data, fun, output = FALSE, stage = NULL, ...) {
 #'   only records that failed the specified check. If TRUE, invisibly prints an
 #'   excel output file containing only the records that failed the specified
 #'   check.
+#' @param loc An optional character string that can be used to specify the desired 
+#' location of the error output. Can only be used when output = TRUE. If output = TRUE
+#' and loc is NULL, the error output gets put into the working directory.
 #' @param stage An optional character string that can be used to specify the
 #'   stage of the checking process in which the check is occurring. Only useful
 #'   if output = TRUE. If a value is specified, a that value is prefixed to the
@@ -84,14 +90,14 @@ col_check <- function(colname, data, fun, output = FALSE, stage = NULL, ...) {
 #' @export
 
 two_col_check <- function(colname1, colname2, data, fun, output = FALSE,
-                          stage = NULL, ...){
+                          loc = NULL, stage = NULL, ...){
   check_name <- paste0(colname1, "_check")
   data[,check_name] <- mapply(FUN = fun, data[colname1], data[colname2])
 
   if(sum(data[,check_name]) != nrow(data)){
     temp <- data[which(data[,check_name] != TRUE),]
     temp <- temp[, !names(temp) == check_name, drop = FALSE]
-    check_return(errors = temp, output = output, stage = stage, check_name =
+    check_return(errors = temp, output = output, loc = loc, stage = stage, check_name =
                    check_name)
   }
 }
@@ -117,6 +123,9 @@ two_col_check <- function(colname1, colname2, data, fun, output = FALSE,
 #'   only records that failed the specified check. If TRUE, invisibly prints an
 #'   excel output file containing only the records that failed the specified
 #'   check.
+#' @param loc An optional character string that can be used to specify the desired 
+#' location of the error output. Can only be used when output = TRUE. If output = TRUE
+#' and loc is NULL, the error output gets put into the working directory.
 #' @param stage An optional character string that can be used to specify the
 #'   stage of the checking process in which the check is occurring. Only useful
 #'   if output = TRUE. If a value is specified, a that value is prefixed to the
@@ -138,7 +147,7 @@ two_col_check <- function(colname1, colname2, data, fun, output = FALSE,
 #' @export
 
 three_col_check <- function(colname1, colname2, colname3, data = data, fun,
-                            output = FALSE, stage = NULL, ...){
+                            output = FALSE, loc = NULL, stage = NULL, ...){
   check_name <- paste0(colname1, "_check")
   data[,check_name] <- mapply(FUN = fun, data[colname1], data[colname2],
                               data[colname3])
@@ -146,7 +155,7 @@ three_col_check <- function(colname1, colname2, colname3, data = data, fun,
   if(sum(data[,check_name]) != nrow(data)){
     temp <- data[which(data[,check_name] != TRUE),]
     temp <- temp[, !names(temp) == check_name, drop = FALSE]
-    check_return(errors = temp, output = output, stage = stage, check_name =
+    check_return(errors = temp, output = output, loc = loc, stage = stage, check_name =
                    check_name)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,13 +1,21 @@
-check_return <- function(errors, output, stage, check_name = check_name){
+check_return <- function(errors, output, loc, stage, check_name = check_name){
   date <- format.Date(Sys.Date(), "%Y%m%d")
   if(output == FALSE){
     return(errors)
-  } else if (output == TRUE){
+  } else if (output == TRUE & is.null(loc)){
     if(is.null(stage)){
       openxlsx::write.xlsx(errors, paste0(check_name, "_errors_",
                                           date, ".xlsx"))
     } else {
       openxlsx::write.xlsx(errors, paste0(stage, "_", check_name, "_errors_",
+                                          date, ".xlsx"))
+    }
+  } else if (output == TRUE & !is.null(loc)){
+    if(is.null(stage)){
+      openxlsx::write.xlsx(errors, paste0(loc, "/", check_name, "_errors_",
+                                          date, ".xlsx"))
+    } else {
+      openxlsx::write.xlsx(errors, paste0(loc, "/", stage, "_", check_name, "_errors_",
                                           date, ".xlsx"))
     }
   }

--- a/man/col_check.Rd
+++ b/man/col_check.Rd
@@ -4,7 +4,7 @@
 \alias{col_check}
 \title{Check a single column for data fidelity.}
 \usage{
-col_check(colname, data, fun, output = FALSE, stage = NULL, ...)
+col_check(colname, data, fun, output = FALSE, loc = NULL, stage = NULL, ...)
 }
 \arguments{
 \item{colname}{character string specifying the name of the column within your
@@ -18,6 +18,10 @@ dataframe.}
 only records that failed the specified check. If TRUE, invisibly prints an
 excel output file containing only the records that failed the specified
 check.}
+
+\item{loc}{An optional character string that can be used to specify the desired 
+location of the error output. Can only be used when output = TRUE. If output = TRUE
+and loc is NULL, the error output gets put into the working directory.}
 
 \item{stage}{An optional character string that can be used to specify the
 stage of the checking process in which the check is occurring. Only useful
@@ -35,7 +39,10 @@ col_check(output = TRUE) invisibly prints an excel output file
   containing only records that failed the specified check.
 }
 \description{
-Check a single column for data fidelity.
+To be used with user-defined functions or with built-in check functions such
+as \code{\link{numeric_check}}, \code{\link{character_check}},
+\code{\link{character_blanks_check}}, \code{\link{date_check}}, and
+\code{\link{val_check}}.
 }
 \examples{
 col_check(colname = "ID_var", data = dataset, fun = numeric_check,

--- a/man/dataset.Rd
+++ b/man/dataset.Rd
@@ -5,10 +5,12 @@
 \alias{dataset}
 \title{Demonstration data created to resemble data collected from an educational
 assessment.}
-\format{A data frame with 20 rows and 5 variables: \describe{ \item{ID_var}{A
+\format{
+A data frame with 20 rows and 5 variables: \describe{ \item{ID_var}{A
   student identification variable} \item{FName}{First names of each student}
   \item{Var1}{One score} \item{Var2}{A second score} \item{Perf_Lvl}{Each
-  student's performance level} \item{dates}{Birthdates}}}
+  student's performance level} \item{dates}{Birthdates}}
+}
 \usage{
 dataset
 }

--- a/man/inspectr.Rd
+++ b/man/inspectr.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{inspectr}
 \alias{inspectr}
-\alias{inspectr-package}
 \title{inspectr: A package for performing fidelity checks on messy dataframes.}
 \description{
 The inspectr package contains two classes of functions: column checks and

--- a/man/three_col_check.Rd
+++ b/man/three_col_check.Rd
@@ -5,8 +5,17 @@
 \title{Check a column for data fidelity using criteria related to two additional
 columns.}
 \usage{
-three_col_check(colname1, colname2, colname3, data = data, fun,
-  output = FALSE, stage = NULL, ...)
+three_col_check(
+  colname1,
+  colname2,
+  colname3,
+  data = data,
+  fun,
+  output = FALSE,
+  loc = NULL,
+  stage = NULL,
+  ...
+)
 }
 \arguments{
 \item{colname1}{character string specifying the name of the column within
@@ -27,6 +36,10 @@ only records that failed the specified check. If TRUE, invisibly prints an
 excel output file containing only the records that failed the specified
 check.}
 
+\item{loc}{An optional character string that can be used to specify the desired 
+location of the error output. Can only be used when output = TRUE. If output = TRUE
+and loc is NULL, the error output gets put into the working directory.}
+
 \item{stage}{An optional character string that can be used to specify the
 stage of the checking process in which the check is occurring. Only useful
 if output = TRUE. If a value is specified, a that value is prefixed to the
@@ -43,8 +56,9 @@ col_check(output = TRUE) invisibly prints an excel output file
   containing only records that failed the specified check.
 }
 \description{
-Check a column for data fidelity using criteria related to two additional
-columns.
+To be used with user-defined functions. The example below illustrates an
+example of a user-defined function that could be defined to use with this
+function.
 }
 \examples{
 three_col_check(colname1 = "Perf_Lvl", colname2 = "Var1", colname3 = "Var2",

--- a/man/two_col_check.Rd
+++ b/man/two_col_check.Rd
@@ -4,8 +4,16 @@
 \alias{two_col_check}
 \title{Check a column for data fidelity using criteria related to a second column.}
 \usage{
-two_col_check(colname1, colname2, data, fun, output = FALSE, stage = NULL,
-  ...)
+two_col_check(
+  colname1,
+  colname2,
+  data,
+  fun,
+  output = FALSE,
+  loc = NULL,
+  stage = NULL,
+  ...
+)
 }
 \arguments{
 \item{colname1}{character string specifying the name of the column within
@@ -23,6 +31,10 @@ only records that failed the specified check. If TRUE, invisibly prints an
 excel output file containing only the records that failed the specified
 check.}
 
+\item{loc}{An optional character string that can be used to specify the desired 
+location of the error output. Can only be used when output = TRUE. If output = TRUE
+and loc is NULL, the error output gets put into the working directory.}
+
 \item{stage}{An optional character string that can be used to specify the
 stage of the checking process in which the check is occurring. Only useful
 if output = TRUE. If a value is specified, a that value is prefixed to the
@@ -39,7 +51,9 @@ col_check(output = TRUE) invisibly prints an excel output file
   containing only records that failed the specified check.
 }
 \description{
-Check a column for data fidelity using criteria related to a second column.
+To be used with user-defined functions or with built-in check functions such
+as \code{\link{less_than}}, \code{\link{less_than_equalto}},
+\code{\link{greater_than}}, and \code{\link{greater_than_equalto}}.
 }
 \examples{
 two_col_check("Var1", "Var2", dataset, less_than_equalto, output = FALSE)


### PR DESCRIPTION
This pull request contains the following changes:
- Edit `check_return()` function to include an optional `loc` argument. `loc` is meant to be a character string that is a file path location. When `loc` is not specified and the argument `output` = TRUE, the error output file is placed in the working directory. When `loc` is specified and `output` = TRUE, the error output file is placed in `loc`. The purpose of having a `loc` argument is to have more control over where the error output goes, without having to use `setwd()` to change the working directory. 
- Edit `col_check()`, `two_col_check()` and `three_col_check()` to include the `loc` argument since `check_return()` is called within these functions.
- Update documentation of the above functions to include `loc` argument (while i ran `document()`, the .Rd files for `dataset` and `inspectr` also got auto-updated)
- Edit DESCRIPTION file to include myself as aut/cre and remove Jennifer as maintainer
